### PR TITLE
fix: 収集ログでRSSフィード名が「不明」と表示される問題を修正

### DIFF
--- a/src/app/api/collect/logs/route.ts
+++ b/src/app/api/collect/logs/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: NextRequest) {
 
   const { data, error } = await supabase
     .from("collection_logs")
-    .select("*, keywords(keyword)")
+    .select("*, keywords(keyword), rss_feeds(name)")
     .order("executed_at", { ascending: false })
     .limit(limit);
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -5,11 +5,13 @@ import { useState, useEffect, useCallback } from "react";
 type CollectionLog = {
   id: string;
   keyword_id: string;
+  feed_id: string | null;
   status: string;
   papers_found: number;
   message: string | null;
   executed_at: string;
   keywords: { keyword: string } | null;
+  rss_feeds: { name: string } | null;
 };
 
 type CollectSummary = {
@@ -538,7 +540,16 @@ export default function SettingsPage() {
                   />
                   <div>
                     <span className="text-sm text-gray-900 dark:text-white">
-                      {log.keywords?.keyword || "不明"}
+                      {log.keywords?.keyword ? (
+                        log.keywords.keyword
+                      ) : log.rss_feeds?.name ? (
+                        <span className="flex items-center gap-1">
+                          <span className="rounded bg-orange-100 px-1 text-xs text-orange-600 dark:bg-orange-900/30 dark:text-orange-400">RSS</span>
+                          {log.rss_feeds.name}
+                        </span>
+                      ) : (
+                        "不明"
+                      )}
                     </span>
                     {log.message && (
                       <p className="text-xs text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
## Summary
- 収集ログ取得API (`/api/collect/logs`) で `rss_feeds` テーブルもJOINするように修正
- 設定画面の `CollectionLog` 型に `feed_id` と `rss_feeds` フィールドを追加
- RSS収集ログにはオレンジの「RSS」バッジ付きでフィード名を表示し、キーワード収集と視覚的に区別

## Test plan
- [ ] 設定画面の収集ログセクションでRSS収集のログにフィード名が表示されることを確認
- [ ] キーワード収集のログは従来通りキーワード名が表示されることを確認
- [ ] RSSログに「RSS」バッジが表示され、キーワードログと視覚的に区別できることを確認
- [ ] `keyword_id` も `feed_id` もnullのログは「不明」と表示されることを確認

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)