### PR TITLE
improve: 収集ログメッセージに重複除外の内訳を追加

### DIFF
--- a/src/lib/rss-collector.ts
+++ b/src/lib/rss-collector.ts
@@ -97,6 +97,7 @@ async function collectForFeed(
 
     // DOIベースの重複排除（DB内の既存論文との照合）
     const newEntries = await filterExistingEntries(entries);
+    const duplicateCount = entries.length - newEntries.length;
 
     let savedCount = 0;
 
@@ -166,7 +167,7 @@ async function collectForFeed(
       feed_name: feed.name,
       status: "success",
       papers_found: savedCount,
-      message: `${entries.length}件中${savedCount}件を新規登録`,
+      message: buildRssLogMessage(entries.length, duplicateCount, savedCount),
     };
 
     await supabase.from("collection_logs").insert({
@@ -196,6 +197,22 @@ async function collectForFeed(
       message,
     };
   }
+}
+
+/**
+ * RSS収集ログメッセージを組み立てる
+ */
+function buildRssLogMessage(
+  totalCount: number,
+  duplicateCount: number,
+  savedCount: number,
+): string {
+  const parts: string[] = [`${totalCount}件取得`];
+  if (duplicateCount > 0) {
+    parts.push(`${duplicateCount}件は既存`);
+  }
+  parts.push(`${savedCount}件を新規登録`);
+  return parts.join("、");
 }
 
 /**


### PR DESCRIPTION
## Summary
- RSS収集ログに既存（重複）件数の内訳を表示するよう改善
- キーワード収集ログにAPI間重複・ジャーナルフィルタ除外・DB既存の内訳を表示するよう改善
- 0件の項目は省略して冗長さを回避

### メッセージ例
- RSS: `90件取得、90件は既存、0件を新規登録`
- キーワード: `10件取得、API間重複2件、DB既存3件、5件を新規登録`

## Test plan
- [ ] RSS収集ログに重複件数が表示されることを確認
- [ ] キーワード収集ログにAPI間重複・ジャーナルフィルタ除外・DB既存の内訳が表示されることを確認
- [ ] 重複が0件の場合はその項目が省略されることを確認
- [ ] 設定画面の収集ログUIに変更がないことを確認

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)