### PR TITLE
feat: 引用探索用DBスキーマ変更 (#9)

### DIFF
--- a/supabase/migrations/001_add_citation_explorer_columns.sql
+++ b/supabase/migrations/001_add_citation_explorer_columns.sql
@@ -1,0 +1,21 @@
+-- 引用ネットワーク探索機能: カラム追加マイグレーション
+-- Issue #9: https://github.com/Buchi0223/Paper_box/issues/9
+-- Supabase SQL Editorで実行してください
+
+-- 1. papers テーブルに citation_explored_at カラム追加
+ALTER TABLE papers ADD COLUMN IF NOT EXISTS citation_explored_at TIMESTAMPTZ DEFAULT NULL;
+
+-- 2. collection_logs テーブルに seed_paper_id カラム追加
+ALTER TABLE collection_logs ADD COLUMN IF NOT EXISTS seed_paper_id UUID REFERENCES papers(id) ON DELETE SET NULL;
+
+-- 3. 未探索シード論文の検索用インデックス
+CREATE INDEX IF NOT EXISTS idx_papers_citation_unexplored ON papers(collected_at DESC) WHERE citation_explored_at IS NULL;
+
+-- 検証: 以下のクエリでカラム存在を確認
+-- SELECT column_name FROM information_schema.columns WHERE table_name = 'papers' AND column_name = 'citation_explored_at';
+-- SELECT column_name FROM information_schema.columns WHERE table_name = 'collection_logs' AND column_name = 'seed_paper_id';
+
+-- ロールバック（必要な場合）:
+-- DROP INDEX IF EXISTS idx_papers_citation_unexplored;
+-- ALTER TABLE collection_logs DROP COLUMN IF EXISTS seed_paper_id;
+-- ALTER TABLE papers DROP COLUMN IF EXISTS citation_explored_at;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -21,6 +21,7 @@ CREATE TABLE papers (
   memo TEXT,
   review_status TEXT NOT NULL DEFAULT 'approved',
   relevance_score INTEGER,
+  citation_explored_at TIMESTAMPTZ DEFAULT NULL,
   collected_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -59,6 +60,7 @@ CREATE TABLE collection_logs (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   keyword_id UUID REFERENCES keywords(id) ON DELETE CASCADE,
   feed_id UUID REFERENCES rss_feeds(id) ON DELETE SET NULL,
+  seed_paper_id UUID REFERENCES papers(id) ON DELETE SET NULL,
   status TEXT NOT NULL DEFAULT 'success',
   papers_found INTEGER NOT NULL DEFAULT 0,
   message TEXT,
@@ -99,6 +101,7 @@ CREATE INDEX idx_papers_relevance_score ON papers(relevance_score) WHERE relevan
 CREATE INDEX idx_keywords_is_active ON keywords(is_active) WHERE is_active = TRUE;
 CREATE INDEX idx_rss_feeds_is_active ON rss_feeds(is_active) WHERE is_active = TRUE;
 CREATE INDEX idx_collection_logs_executed_at ON collection_logs(executed_at DESC);
+CREATE INDEX idx_papers_citation_unexplored ON papers(collected_at DESC) WHERE citation_explored_at IS NULL;
 
 -- updated_at を自動更新するトリガー
 CREATE OR REPLACE FUNCTION update_updated_at()


### PR DESCRIPTION
## Summary
- `papers` テーブルに `citation_explored_at` (TIMESTAMPTZ, NULL許可) カラムを追加 — お気に入り/承認済み論文の引用探索済みフラグ
- `collection_logs` テーブルに `seed_paper_id` (UUID, FK→papers, ON DELETE SET NULL) カラムを追加 — 引用探索ログのシード論文参照
- 未探索シード論文を効率的に検索する部分インデックス `idx_papers_citation_unexplored` を追加
- Supabase SQL Editor用のマイグレーションファイル `supabase/migrations/001_add_citation_explorer_columns.sql` を追加

## 変更ファイル
- `supabase/schema.sql` — テーブル定義にカラム・インデックス追加
- `supabase/migrations/001_add_citation_explorer_columns.sql` — 既存DB向けALTER TABLE文（新規）

## デプロイ手順
1. PR マージ後、Supabase SQL Editor で `supabase/migrations/001_add_citation_explorer_columns.sql` を実行
2. 検証クエリで確認:
   ```sql
   SELECT column_name FROM information_schema.columns WHERE table_name = 'papers' AND column_name = 'citation_explored_at';
   SELECT column_name FROM information_schema.columns WHERE table_name = 'collection_logs' AND column_name = 'seed_paper_id';
   ```

## Test plan
- [ ] `npm run build` が成功すること（✅ 確認済み）
- [ ] Supabase SQL Editorでマイグレーション実行
- [ ] 既存データ・クエリに影響がないこと（NULLableカラムのみ追加）

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)