### PR TITLE
feat: 論文詳細ページに「解説を生成」ボタンを追加

### DIFF
--- a/src/app/papers/[id]/page.tsx
+++ b/src/app/papers/[id]/page.tsx
@@ -18,6 +18,7 @@ export default function PaperDetailPage({ params }: { params: Promise<{ id: stri
   const [isSavingMemo, setIsSavingMemo] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isGeneratingExplanation, setIsGeneratingExplanation] = useState(false);
 
   useEffect(() => {
     const fetchPaper = async () => {
@@ -68,6 +69,31 @@ export default function PaperDetailPage({ params }: { params: Promise<{ id: stri
       setShowDeleteConfirm(false);
     } finally {
       setIsDeleting(false);
+    }
+  };
+
+  const handleGenerateExplanation = async () => {
+    if (!paper) return;
+    setIsGeneratingExplanation(true);
+    try {
+      const res = await fetch("/api/ai/explain", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          paper_id: paper.id,
+          title_original: paper.title_original,
+          authors: paper.authors,
+          abstract: paper.abstract,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed");
+      const data = await res.json();
+      setPaper({ ...paper, explanation_ja: data.explanation });
+      showToast("解説を生成しました", "success");
+    } catch {
+      showToast("解説の生成に失敗しました", "error");
+    } finally {
+      setIsGeneratingExplanation(false);
     }
   };
 
@@ -200,14 +226,37 @@ export default function PaperDetailPage({ params }: { params: Promise<{ id: stri
       )}
 
       {/* 解説 */}
-      {paper.explanation_ja && (
-        <section className="mb-6 rounded-lg border border-gray-200 p-5 dark:border-gray-700">
-          <h2 className="mb-3 text-lg font-semibold text-gray-900 dark:text-white">解説</h2>
+      <section className="mb-6 rounded-lg border border-gray-200 p-5 dark:border-gray-700">
+        <h2 className="mb-3 text-lg font-semibold text-gray-900 dark:text-white">解説</h2>
+        {paper.explanation_ja ? (
           <p className="whitespace-pre-wrap leading-relaxed text-gray-700 dark:text-gray-300">
             {paper.explanation_ja}
           </p>
-        </section>
-      )}
+        ) : (
+          <div className="text-center py-4">
+            <p className="mb-3 text-sm text-gray-500 dark:text-gray-400">
+              この論文の解説はまだありません
+            </p>
+            <button
+              onClick={handleGenerateExplanation}
+              disabled={isGeneratingExplanation}
+              className="inline-flex items-center gap-2 rounded-lg border border-blue-300 bg-blue-50 px-4 py-2 text-sm font-medium text-blue-700 hover:bg-blue-100 disabled:opacity-50 dark:border-blue-600 dark:bg-blue-900/20 dark:text-blue-400 dark:hover:bg-blue-900/30"
+            >
+              {isGeneratingExplanation ? (
+                <>
+                  <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                  </svg>
+                  解説を生成中...
+                </>
+              ) : (
+                "解説を生成"
+              )}
+            </button>
+          </div>
+        )}
+      </section>
 
       {/* メモ */}
       <section className="mb-6 rounded-lg border border-gray-200 p-5 dark:border-gray-700">


### PR DESCRIPTION
## Summary
- `explanation_ja` が未生成の論文詳細ページに「解説を生成」ボタンを追加
- ボタン押下で `/api/ai/explain` にPOSTし、解説を生成・表示
- 生成中はスピナー付きローディング表示、成功/失敗時にToast通知

Closes #27

## 変更ファイル
- `src/app/papers/[id]/page.tsx` — 解説生成ボタンUI + API呼び出しロジック追加

## Test plan
- [ ] `explanation_ja` が null の論文でボタンが表示されること
- [ ] ボタン押下で `/api/ai/explain` にPOSTされること
- [ ] 生成中はローディング表示・ボタン無効化されること
- [ ] 成功時に解説テキストが表示され、ボタンが消えること
- [ ] 失敗時にエラーToastが表示されること
- [ ] `explanation_ja` が既にある論文ではボタンが表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)