### PR TITLE
feat: Bulk APIに skip_all_auto_skipped アクションを追加

### DIFF
--- a/src/app/api/papers/review/bulk/route.ts
+++ b/src/app/api/papers/review/bulk/route.ts
@@ -7,6 +7,7 @@ import { supabase } from "@/lib/supabase";
  * action:
  *   - "approve_all_auto": min_score 以上の pending 論文を一括承認
  *   - "skip_all_auto": max_score 以下の pending 論文を一括スキップ
+ *   - "skip_all_auto_skipped": auto_skipped 論文を一括スキップ
  */
 export async function POST(request: NextRequest) {
   const body = await request.json();
@@ -19,50 +20,74 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  if (action === "approve_all_auto") {
-    const threshold = min_score ?? 70;
+  switch (action) {
+    case "approve_all_auto": {
+      const threshold = min_score ?? 70;
 
-    const { data, error } = await supabase
-      .from("papers")
-      .update({ review_status: "approved" })
-      .eq("review_status", "pending")
-      .gte("relevance_score", threshold)
-      .select("id");
+      const { data, error } = await supabase
+        .from("papers")
+        .update({ review_status: "approved" })
+        .eq("review_status", "pending")
+        .gte("relevance_score", threshold)
+        .select("id");
 
-    if (error) {
-      return NextResponse.json({ error: error.message }, { status: 500 });
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+
+      return NextResponse.json({
+        success: true,
+        action: "approve_all_auto",
+        affected_count: data?.length ?? 0,
+      });
     }
 
-    return NextResponse.json({
-      success: true,
-      action: "approve_all_auto",
-      affected_count: data?.length || 0,
-    });
-  }
+    case "skip_all_auto": {
+      const threshold = max_score ?? 30;
 
-  if (action === "skip_all_auto") {
-    const threshold = max_score ?? 30;
+      const { data, error } = await supabase
+        .from("papers")
+        .update({ review_status: "skipped" })
+        .eq("review_status", "pending")
+        .lte("relevance_score", threshold)
+        .select("id");
 
-    const { data, error } = await supabase
-      .from("papers")
-      .update({ review_status: "skipped" })
-      .eq("review_status", "pending")
-      .lte("relevance_score", threshold)
-      .select("id");
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
 
-    if (error) {
-      return NextResponse.json({ error: error.message }, { status: 500 });
+      return NextResponse.json({
+        success: true,
+        action: "skip_all_auto",
+        affected_count: data?.length ?? 0,
+      });
     }
 
-    return NextResponse.json({
-      success: true,
-      action: "skip_all_auto",
-      affected_count: data?.length || 0,
-    });
-  }
+    case "skip_all_auto_skipped": {
+      const { data, error } = await supabase
+        .from("papers")
+        .update({ review_status: "skipped" })
+        .eq("review_status", "auto_skipped")
+        .select("id");
 
-  return NextResponse.json(
-    { error: "action は 'approve_all_auto' または 'skip_all_auto' を指定してください" },
-    { status: 400 },
-  );
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+
+      return NextResponse.json({
+        success: true,
+        action: "skip_all_auto_skipped",
+        affected_count: data?.length ?? 0,
+      });
+    }
+
+    default:
+      return NextResponse.json(
+        {
+          error:
+            "action は 'approve_all_auto', 'skip_all_auto', 'skip_all_auto_skipped' のいずれかを指定してください",
+        },
+        { status: 400 },
+      );
+  }
 }


### PR DESCRIPTION
## Summary
- 既存の `if-else` チェーンを `switch` 文にリファクタリングし可読性を向上
- `skip_all_auto_skipped` アクションを追加: `auto_skipped` ステータスの論文を一括で `skipped` に更新
- 不正アクション時の400エラーメッセージを更新

Closes #28

## Test plan
- [ ] `skip_all_auto_skipped` アクションで `auto_skipped` 論文のみが更新されること
- [ ] `pending` 論文が影響を受けないこと
- [ ] `affected_count` が正しく返ること
- [ ] 不正なアクション名で400エラーが返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)