### PR TITLE
feat: papersテーブルにNotion連携用カラムを追加

### DIFF
--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -57,6 +57,8 @@ export type Paper = {
   explanation_ja: string | null;
   source: string;
   google_drive_url: string | null;
+  notion_page_id: string | null;
+  notion_page_url: string | null;
   is_favorite: boolean;
   memo: string | null;
   review_status: string;
@@ -80,6 +82,8 @@ export type PaperInsert = {
   explanation_ja?: string | null;
   source?: string;
   google_drive_url?: string | null;
+  notion_page_id?: string | null;
+  notion_page_url?: string | null;
   is_favorite?: boolean;
   memo?: string | null;
   review_status?: string;
@@ -103,6 +107,8 @@ export type PaperUpdate = {
   explanation_ja?: string | null;
   source?: string;
   google_drive_url?: string | null;
+  notion_page_id?: string | null;
+  notion_page_url?: string | null;
   is_favorite?: boolean;
   memo?: string | null;
   review_status?: string;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -17,6 +17,8 @@ CREATE TABLE papers (
   explanation_ja TEXT,
   source TEXT NOT NULL DEFAULT 'manual',
   google_drive_url TEXT,
+  notion_page_id TEXT,
+  notion_page_url TEXT,
   is_favorite BOOLEAN NOT NULL DEFAULT FALSE,
   memo TEXT,
   review_status TEXT NOT NULL DEFAULT 'approved',


### PR DESCRIPTION
## Summary
- `supabase/schema.sql`: papersテーブルに`notion_page_id`(TEXT)、`notion_page_url`(TEXT)カラムを追加
- `src/types/database.ts`: `Paper`, `PaperInsert`, `PaperUpdate`型に対応フィールドを追加

## Test plan
- [ ] schema.sqlに`notion_page_id`, `notion_page_url`カラム定義が追加されている
- [ ] TypeScript型（Paper, PaperInsert, PaperUpdate）が更新されている
- [ ] `npm run build`が成功する
- [ ] Supabaseダッシュボードで`ALTER TABLE`を実行後、既存APIで新フィールドが返却される

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)