### PR TITLE
feat: Google Drive OAuth ヘルパーライブラリ (#55)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,9 @@ src/
 ├── app/              # Next.js App Router ページ・APIルート
 │   ├── api/          # APIエンドポイント
 │   │   ├── ai/        # AI要約・解説生成
+│   │   ├── auth/      # Google OAuth認証（接続・コールバック・ステータス・切断）
 │   │   ├── collect/   # 論文収集トリガー
 │   │   ├── cron/      # Vercel Cron（定期自動収集）
-│   │   ├── auth/       # Google OAuth認証（接続・コールバック・ステータス・切断）
 │   │   ├── drive/     # Google Drive連携
 │   │   ├── feeds/     # RSSフィード管理
 │   │   ├── interests/ # 関心プロファイル管理

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ src/
 │   │   ├── ai/        # AI要約・解説生成
 │   │   ├── collect/   # 論文収集トリガー
 │   │   ├── cron/      # Vercel Cron（定期自動収集）
+│   │   ├── auth/       # Google OAuth認証（接続・コールバック・ステータス・切断）
 │   │   ├── drive/     # Google Drive連携
 │   │   ├── feeds/     # RSSフィード管理
 │   │   ├── interests/ # 関心プロファイル管理
@@ -53,7 +54,8 @@ src/
 │   ├── openalex.ts     # OpenAlex API連携
 │   ├── semantic-scholar.ts # Semantic Scholar API連携
 │   ├── rss.ts          # RSSパーサー
-│   ├── google-drive.ts # Google Drive連携
+│   ├── google-drive.ts # Google Drive連携（OAuth/サービスアカウント デュアルモード認証）
+│   ├── google-oauth.ts # Google OAuth 2.0ヘルパー（トークン管理・認証URL生成）
 │   ├── notion.ts       # Notion API連携
 │   └── interest-learner.ts # 関心学習
 └── types/
@@ -69,13 +71,15 @@ supabase/
 - `rss_feeds` — RSSフィード登録
 - `collection_logs` — 収集実行ログ
 - `interests` — 関心プロファイル
-- `review_settings` — スコアリング閾値・機能設定・Notion連携設定（`notion_database_id`）
+- `review_settings` — スコアリング閾値・機能設定・Notion連携設定・Google OAuth トークン
 
 ## 環境変数
 必要な環境変数（`.env.local`）:
 - `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` — Supabase接続
 - `GEMINI_API_KEY` — Gemini AI API
-- `GOOGLE_DRIVE_FOLDER_ID` / Google Drive認証情報 — Google Drive連携
+- `GOOGLE_DRIVE_FOLDER_ID` — Google Drive保存先フォルダID
+- `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` — Google OAuth 2.0クライアント認証情報
+- `GOOGLE_SERVICE_ACCOUNT_KEY` — サービスアカウント認証情報（オプション、OAuth未接続時のフォールバック）
 - `CRON_SECRET` — Vercel Cronの認証
 - `NOTION_TOKEN` — Notion Internal Integration Token（Notion連携）
 

--- a/docs/api-specification.md
+++ b/docs/api-specification.md
@@ -666,11 +666,106 @@ PDFファイルをGoogle Driveにアップロードする。
 }
 ```
 
-**エラーレスポンス** `400 Bad Request` — PDF以外のファイル
+**エラーレスポンス**
+
+- `400 Bad Request` — PDF以外のファイル
+- `500 Internal Server Error` — Google Drive認証エラー
+
+```json
+{
+  "error": "エラーメッセージ",
+  "error_code": "env_not_configured"
+}
+```
+
+**エラーコード一覧**
+
+| コード | 説明 |
+|--------|------|
+| `env_not_configured` | OAuth未接続かつサービスアカウント未設定 |
+| `invalid_config` | サービスアカウント設定が不正 |
+
+**備考**: OAuth認証優先、未接続時はサービスアカウントにフォールバック。両方未設定の場合は `env_not_configured` エラー。
 
 ---
 
-## 9. 論文収集 (Collection)
+## 9. Google OAuth認証 (Auth)
+
+### GET /api/auth/google
+
+Google OAuth 2.0 認証を開始する。Googleの同意画面へリダイレクトする。
+
+**クエリパラメータ**
+
+| パラメータ | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `returnTo` | string | `/settings` | 認証完了後のリダイレクト先（相対パスのみ） |
+
+**レスポンス** `302 Found` — Google OAuth 同意画面へリダイレクト
+
+**エラーレスポンス** `302 Found` — `/settings?error=google_auth_failed` へリダイレクト
+
+**備考**: `returnTo` が相対パスでない場合はオープンリダイレクト防止のため `/settings` にフォールバックする。
+
+---
+
+### GET /api/auth/google/callback
+
+Google OAuth コールバック。認証コードをトークンに交換し、DBに保存する。
+
+**クエリパラメータ**
+
+| パラメータ | 型 | 説明 |
+|---|---|---|
+| `code` | string | Google OAuth 認証コード |
+| `state` | string | リダイレクト先パス（`returnTo` から引き継ぎ） |
+
+**レスポンス** `302 Found` — `state` で指定されたパスへリダイレクト
+
+**エラーレスポンス** `302 Found` — `/settings?error=google_auth_failed` へリダイレクト
+
+**副作用**: `review_settings` テーブルに `google_drive_refresh_token` と `google_drive_email` を保存。
+
+---
+
+### GET /api/auth/google/status
+
+Google Drive の接続状態を取得する。
+
+**レスポンス** `200 OK`
+
+```json
+{
+  "connected": true,
+  "email": "user@gmail.com"
+}
+```
+
+**備考**: トークンが存在しない場合は `{ "connected": false, "email": null }` を返す。
+
+---
+
+### POST /api/auth/google/disconnect
+
+Google Drive 接続を解除する。トークンを失効させ、DBから削除する。
+
+**レスポンス** `200 OK`
+
+```json
+{ "success": true }
+```
+
+**エラーレスポンス** `500 Internal Server Error`
+
+```json
+{ "error": "切断に失敗しました" }
+```
+
+**副作用**: Google APIでトークンを失効させ、`review_settings` から `google_drive_refresh_token` と `google_drive_email` をクリアする。
+
+---
+
+## 10. 論文収集 (Collection)
 
 ### POST /api/collect
 
@@ -743,7 +838,7 @@ PDFファイルをGoogle Driveにアップロードする。
 
 ---
 
-## 10. Cron (定期自動収集)
+## 11. Cron (定期自動収集)
 
 ### GET / POST /api/cron/collect
 
@@ -784,7 +879,7 @@ Vercel Cronから毎日06:00 UTCに呼び出される自動収集エンドポイ
 
 ---
 
-## 11. 設定 (Settings)
+## 12. 設定 (Settings)
 
 ### GET /api/settings/review
 
@@ -844,7 +939,7 @@ Vercel Cronから毎日06:00 UTCに呼び出される自動収集エンドポイ
 
 ---
 
-## 12. スコアリング診断 (Scoring)
+## 13. スコアリング診断 (Scoring)
 
 ### GET /api/scoring/test
 
@@ -923,7 +1018,7 @@ Vercel Cronから毎日06:00 UTCに呼び出される自動収集エンドポイ
 
 ---
 
-## 13. Notion連携 (Notion)
+## 14. Notion連携 (Notion)
 
 ### GET /api/notion/settings
 
@@ -1043,6 +1138,10 @@ Notion接続テストを実行する。
 | POST | `/api/ai/explain` | AI解説生成 |
 | POST | `/api/pdf/parse` | PDF解析 |
 | POST | `/api/drive/upload` | Google Driveアップロード |
+| GET | `/api/auth/google` | Google OAuth認証開始 |
+| GET | `/api/auth/google/callback` | Google OAuthコールバック |
+| GET | `/api/auth/google/status` | Google Drive接続状態取得 |
+| POST | `/api/auth/google/disconnect` | Google Drive接続解除 |
 | POST | `/api/collect` | 手動収集 |
 | GET | `/api/collect/logs` | 収集ログ取得 |
 | GET/POST | `/api/cron/collect` | 定期自動収集 |

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { exchangeCode, saveTokens } from "@/lib/google-oauth";
+
+/**
+ * GET /api/auth/google/callback — Google OAuth コールバック処理
+ */
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get("code");
+  const state = request.nextUrl.searchParams.get("state") || "/settings";
+
+  if (!code) {
+    console.error("[Google OAuth] Callback missing code parameter");
+    return NextResponse.redirect(
+      new URL("/settings?error=google_auth_failed", request.url),
+    );
+  }
+
+  try {
+    const { refreshToken, email } = await exchangeCode(code);
+    await saveTokens(refreshToken, email);
+    return NextResponse.redirect(new URL(state, request.url));
+  } catch (error) {
+    console.error("[Google OAuth] Callback failed:", error);
+    return NextResponse.redirect(
+      new URL("/settings?error=google_auth_failed", request.url),
+    );
+  }
+}

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -6,7 +6,9 @@ import { exchangeCode, saveTokens } from "@/lib/google-oauth";
  */
 export async function GET(request: NextRequest) {
   const code = request.nextUrl.searchParams.get("code");
-  const state = request.nextUrl.searchParams.get("state") || "/settings";
+  const rawState = request.nextUrl.searchParams.get("state") || "/settings";
+  // オープンリダイレクト防止: 相対パスのみ許可
+  const state = rawState.startsWith("/") ? rawState : "/settings";
 
   if (!code) {
     console.error("[Google OAuth] Callback missing code parameter");

--- a/src/app/api/auth/google/disconnect/route.ts
+++ b/src/app/api/auth/google/disconnect/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { revokeAndClear } from "@/lib/google-oauth";
+
+/**
+ * POST /api/auth/google/disconnect — Google Drive 接続を解除
+ */
+export async function POST() {
+  try {
+    await revokeAndClear();
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("[Google OAuth] Disconnect failed:", error);
+    const message =
+      error instanceof Error ? error.message : "切断に失敗しました";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -6,7 +6,9 @@ import { getAuthUrl } from "@/lib/google-oauth";
  */
 export async function GET(request: NextRequest) {
   try {
-    const returnTo = request.nextUrl.searchParams.get("returnTo") || "/settings";
+    const rawReturnTo = request.nextUrl.searchParams.get("returnTo") || "/settings";
+    // オープンリダイレクト防止: 相対パスのみ許可
+    const returnTo = rawReturnTo.startsWith("/") ? rawReturnTo : "/settings";
     const authUrl = getAuthUrl(returnTo);
     return NextResponse.redirect(authUrl);
   } catch (error) {

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthUrl } from "@/lib/google-oauth";
+
+/**
+ * GET /api/auth/google — OAuth 認証開始。Google 同意画面へリダイレクト
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const returnTo = request.nextUrl.searchParams.get("returnTo") || "/settings";
+    const authUrl = getAuthUrl(returnTo);
+    return NextResponse.redirect(authUrl);
+  } catch (error) {
+    console.error("[Google OAuth] Auth start failed:", error);
+    return NextResponse.redirect(
+      new URL("/settings?error=google_auth_failed", request.url),
+    );
+  }
+}

--- a/src/app/api/auth/google/status/route.ts
+++ b/src/app/api/auth/google/status/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+
+/**
+ * GET /api/auth/google/status — Google Drive 接続状態を返す
+ */
+export async function GET() {
+  const { data, error } = await supabase
+    .from("review_settings")
+    .select("key, value")
+    .in("key", ["google_drive_refresh_token", "google_drive_email"]);
+
+  if (error) {
+    return NextResponse.json({ connected: false, email: null });
+  }
+
+  const tokenRow = data?.find((r) => r.key === "google_drive_refresh_token");
+  const emailRow = data?.find((r) => r.key === "google_drive_email");
+
+  const connected = !!tokenRow?.value;
+  const email = emailRow?.value || null;
+
+  return NextResponse.json({ connected, email });
+}

--- a/src/app/api/drive/upload/route.ts
+++ b/src/app/api/drive/upload/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { uploadToDrive } from "@/lib/google-drive";
+import { uploadToDrive, DriveUploadError } from "@/lib/google-drive";
 
 export async function POST(request: NextRequest) {
   try {
@@ -19,6 +19,12 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ url: driveUrl });
   } catch (error) {
+    if (error instanceof DriveUploadError) {
+      return NextResponse.json(
+        { error: error.message, error_code: error.code },
+        { status: 500 },
+      );
+    }
     const message = error instanceof Error ? error.message : "アップロードに失敗しました";
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/src/app/papers/[id]/page.tsx
+++ b/src/app/papers/[id]/page.tsx
@@ -20,6 +20,7 @@ export default function PaperDetailPage({ params }: { params: Promise<{ id: stri
   const [isDeleting, setIsDeleting] = useState(false);
   const [isGeneratingExplanation, setIsGeneratingExplanation] = useState(false);
   const [isUploadingPdf, setIsUploadingPdf] = useState(false);
+  const [driveNotConnected, setDriveNotConnected] = useState(false);
   const [isExportingNotion, setIsExportingNotion] = useState(false);
   const [notionConfigured, setNotionConfigured] = useState<boolean | null>(null);
   const pdfInputRef = useRef<HTMLInputElement>(null);
@@ -150,6 +151,7 @@ export default function PaperDetailPage({ params }: { params: Promise<{ id: stri
     if (!file || !paper) return;
 
     setIsUploadingPdf(true);
+    setDriveNotConnected(false);
     try {
       const formData = new FormData();
       formData.append("file", file);
@@ -157,7 +159,14 @@ export default function PaperDetailPage({ params }: { params: Promise<{ id: stri
         method: "POST",
         body: formData,
       });
-      if (!uploadRes.ok) throw new Error("Upload failed");
+      if (!uploadRes.ok) {
+        const errData = await uploadRes.json().catch(() => null);
+        if (errData?.error_code === "env_not_configured") {
+          setDriveNotConnected(true);
+          return;
+        }
+        throw new Error("Upload failed");
+      }
       const { url } = await uploadRes.json();
 
       const patchRes = await fetch(`/api/papers/${paper.id}`, {
@@ -369,6 +378,24 @@ export default function PaperDetailPage({ params }: { params: Promise<{ id: stri
           </button>
         )}
       </div>
+
+      {/* Google Drive未接続案内 */}
+      {driveNotConnected && (
+        <div className="mb-6 rounded-lg border border-yellow-200 bg-yellow-50 p-4 dark:border-yellow-800 dark:bg-yellow-900/20">
+          <p className="text-sm font-medium text-yellow-800 dark:text-yellow-300">
+            Google Driveに接続されていません
+          </p>
+          <p className="mt-1 text-xs text-yellow-700 dark:text-yellow-400">
+            PDFをアップロードするには、Google Driveアカウントを接続してください。
+          </p>
+          <a
+            href={`/api/auth/google?returnTo=/papers/${id}`}
+            className="mt-2 inline-block rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+          >
+            Google Driveに接続
+          </a>
+        </div>
+      )}
 
       {/* 要約 */}
       {paper.summary_ja && (

--- a/src/app/papers/new/page.tsx
+++ b/src/app/papers/new/page.tsx
@@ -19,6 +19,7 @@ export default function NewPaperPage() {
   const [isParsing, setIsParsing] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [pdfText, setPdfText] = useState<string>("");
+  const [driveNotConnected, setDriveNotConnected] = useState(false);
 
   // AI処理関連
   const [isAiProcessing, setIsAiProcessing] = useState(false);
@@ -138,6 +139,7 @@ export default function NewPaperPage() {
   const uploadPdf = async (): Promise<string | null> => {
     if (!pdfFile) return null;
     setIsUploading(true);
+    setDriveNotConnected(false);
     try {
       const formData = new FormData();
       formData.append("file", pdfFile);
@@ -146,7 +148,11 @@ export default function NewPaperPage() {
         const data = await res.json();
         return data.url;
       }
-      // Google Drive未設定時はスキップ
+      // env_not_configured の場合は接続案内を表示
+      const errData = await res.json().catch(() => null);
+      if (errData?.error_code === "env_not_configured") {
+        setDriveNotConnected(true);
+      }
       return null;
     } catch {
       return null;
@@ -262,6 +268,22 @@ export default function NewPaperPage() {
             <p className="mt-2 text-xs text-green-600 dark:text-green-400">
               {pdfFile.name} を選択済み（Google Drive設定時に自動アップロードされます）
             </p>
+          )}
+          {driveNotConnected && (
+            <div className="mt-3 rounded-lg border border-yellow-200 bg-yellow-50 p-3 dark:border-yellow-800 dark:bg-yellow-900/20">
+              <p className="text-sm font-medium text-yellow-800 dark:text-yellow-300">
+                Google Driveに接続されていません
+              </p>
+              <p className="mt-1 text-xs text-yellow-700 dark:text-yellow-400">
+                PDFをアップロードするには、Google Driveアカウントを接続してください。
+              </p>
+              <a
+                href="/api/auth/google?returnTo=/papers/new"
+                className="mt-2 inline-block rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+              >
+                Google Driveに接続
+              </a>
+            </div>
           )}
         </div>
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import GoogleDriveStatus from "@/components/GoogleDriveStatus";
 
 type CollectionLog = {
   id: string;
@@ -673,6 +674,14 @@ export default function SettingsPage() {
             ))}
           </div>
         )}
+      </section>
+
+      {/* Google Drive連携 */}
+      <section className="rounded-lg border border-gray-200 p-5 dark:border-gray-700">
+        <h2 className="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
+          Google Drive連携
+        </h2>
+        <GoogleDriveStatus variant="settings" />
       </section>
 
       {/* Notion連携 */}

--- a/src/components/GoogleDriveStatus.tsx
+++ b/src/components/GoogleDriveStatus.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { usePathname } from "next/navigation";
+
+interface GoogleDriveStatusProps {
+  variant?: "header" | "settings";
+}
+
+export default function GoogleDriveStatus({
+  variant = "settings",
+}: GoogleDriveStatusProps) {
+  const pathname = usePathname();
+  const [connected, setConnected] = useState(false);
+  const [email, setEmail] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [disconnecting, setDisconnecting] = useState(false);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/api/auth/google/status");
+      if (res.ok) {
+        const data = await res.json();
+        setConnected(data.connected);
+        setEmail(data.email);
+      }
+    } catch {
+      // ステータス取得失敗は無視
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  const handleConnect = () => {
+    window.location.href = `/api/auth/google?returnTo=${encodeURIComponent(pathname)}`;
+  };
+
+  const handleDisconnect = async () => {
+    if (!confirm("Google Drive接続を解除しますか？")) return;
+    setDisconnecting(true);
+    try {
+      const res = await fetch("/api/auth/google/disconnect", {
+        method: "POST",
+      });
+      if (res.ok) {
+        setConnected(false);
+        setEmail(null);
+      }
+    } catch {
+      // 切断失敗
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  // --- Header variant ---
+  if (variant === "header") {
+    if (loading) return null;
+
+    return (
+      <button
+        onClick={connected ? handleDisconnect : handleConnect}
+        disabled={disconnecting}
+        title={
+          connected
+            ? `Google Drive: ${email || "接続済み"}（クリックで切断）`
+            : "Google Driveに接続"
+        }
+        className="rounded-lg p-2 transition-colors hover:bg-gray-100 disabled:opacity-50 dark:hover:bg-gray-800"
+      >
+        <svg
+          className={`h-5 w-5 ${
+            connected
+              ? "text-green-600 dark:text-green-400"
+              : "text-gray-400 dark:text-gray-500"
+          }`}
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path d="M7.71 3.5L1.15 15l4.58 3L12.29 6.5zM12 18.5l-3.58-3h7.16L19.16 18.5zM22.85 15L16.29 3.5h-4.58L18.27 15z" />
+        </svg>
+      </button>
+    );
+  }
+
+  // --- Settings variant ---
+  if (loading) {
+    return (
+      <div className="h-20 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-gray-700 dark:text-gray-300">
+          接続状態:
+        </span>
+        {connected ? (
+          <span className="text-sm font-medium text-green-600 dark:text-green-400">
+            接続済み ({email})
+          </span>
+        ) : (
+          <span className="text-sm font-medium text-red-600 dark:text-red-400">
+            未接続
+          </span>
+        )}
+      </div>
+
+      {connected ? (
+        <button
+          onClick={handleDisconnect}
+          disabled={disconnecting}
+          className="rounded-lg border border-red-300 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-600 dark:text-red-400 dark:hover:bg-red-900/20"
+        >
+          {disconnecting ? "切断中..." : "切断する"}
+        </button>
+      ) : (
+        <button
+          onClick={handleConnect}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          Google Driveに接続
+        </button>
+      )}
+
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        PDFのアップロードにはGoogle Drive接続が必要です
+      </p>
+    </div>
+  );
+}

--- a/src/components/GoogleDriveStatus.tsx
+++ b/src/components/GoogleDriveStatus.tsx
@@ -15,6 +15,7 @@ export default function GoogleDriveStatus({
   const [email, setEmail] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [disconnecting, setDisconnecting] = useState(false);
+  const [disconnectError, setDisconnectError] = useState(false);
 
   const fetchStatus = useCallback(async () => {
     try {
@@ -42,6 +43,7 @@ export default function GoogleDriveStatus({
   const handleDisconnect = async () => {
     if (!confirm("Google Drive接続を解除しますか？")) return;
     setDisconnecting(true);
+    setDisconnectError(false);
     try {
       const res = await fetch("/api/auth/google/disconnect", {
         method: "POST",
@@ -49,9 +51,11 @@ export default function GoogleDriveStatus({
       if (res.ok) {
         setConnected(false);
         setEmail(null);
+      } else {
+        setDisconnectError(true);
       }
     } catch {
-      // 切断失敗
+      setDisconnectError(true);
     } finally {
       setDisconnecting(false);
     }
@@ -65,6 +69,7 @@ export default function GoogleDriveStatus({
       <button
         onClick={connected ? handleDisconnect : handleConnect}
         disabled={disconnecting}
+        aria-label={connected ? "Google Drive接続を解除" : "Google Driveに接続"}
         title={
           connected
             ? `Google Drive: ${email || "接続済み"}（クリックで切断）`
@@ -73,6 +78,7 @@ export default function GoogleDriveStatus({
         className="rounded-lg p-2 transition-colors hover:bg-gray-100 disabled:opacity-50 dark:hover:bg-gray-800"
       >
         <svg
+          aria-hidden="true"
           className={`h-5 w-5 ${
             connected
               ? "text-green-600 dark:text-green-400"
@@ -126,6 +132,12 @@ export default function GoogleDriveStatus({
         >
           Google Driveに接続
         </button>
+      )}
+
+      {disconnectError && (
+        <p className="text-sm text-red-600 dark:text-red-400">
+          切断に失敗しました。もう一度お試しください。
+        </p>
       )}
 
       <p className="text-xs text-gray-500 dark:text-gray-400">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import DarkModeToggle from "./DarkModeToggle";
+import GoogleDriveStatus from "./GoogleDriveStatus";
 
 const navItems = [
   { href: "/", label: "論文一覧" },
@@ -46,11 +47,13 @@ export default function Header() {
               </Link>
             );
           })}
+          <GoogleDriveStatus variant="header" />
           <DarkModeToggle />
         </nav>
 
-        {/* モバイル：ダークモード + ハンバーガー */}
+        {/* モバイル：Drive + ダークモード + ハンバーガー */}
         <div className="flex items-center gap-1 md:hidden">
+          <GoogleDriveStatus variant="header" />
           <DarkModeToggle />
           <button
             onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}

--- a/src/lib/google-drive.ts
+++ b/src/lib/google-drive.ts
@@ -1,15 +1,52 @@
 import { google } from "googleapis";
+import type { OAuth2Client } from "google-auth-library";
 import { Readable } from "stream";
+import { getStoredAuth } from "@/lib/google-oauth";
 
-function getAuth() {
+export class DriveUploadError extends Error {
+  constructor(
+    message: string,
+    public code: string,
+  ) {
+    super(message);
+    this.name = "DriveUploadError";
+  }
+}
+
+type AuthResult = {
+  auth: InstanceType<typeof google.auth.GoogleAuth> | OAuth2Client;
+  isOAuth: boolean;
+};
+
+/**
+ * 認証モード優先順位:
+ * 1. OAuth refresh_token が DB にある → OAuth2 クライアント
+ * 2. GOOGLE_SERVICE_ACCOUNT_KEY 環境変数がある → サービスアカウント
+ * 3. どちらもない → エラー
+ */
+async function getAuth(): Promise<AuthResult> {
+  // 1. OAuth トークンを確認
+  const oauthClient = await getStoredAuth();
+  if (oauthClient) {
+    return { auth: oauthClient, isOAuth: true };
+  }
+
+  // 2. サービスアカウントにフォールバック
   const keyJson = process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
-  if (!keyJson) throw new Error("GOOGLE_SERVICE_ACCOUNT_KEY is not set");
+  if (keyJson) {
+    const key = JSON.parse(keyJson);
+    const googleAuth = new google.auth.GoogleAuth({
+      credentials: key,
+      scopes: ["https://www.googleapis.com/auth/drive.file"],
+    });
+    return { auth: googleAuth, isOAuth: false };
+  }
 
-  const key = JSON.parse(keyJson);
-  return new google.auth.GoogleAuth({
-    credentials: key,
-    scopes: ["https://www.googleapis.com/auth/drive.file"],
-  });
+  // 3. どちらもない
+  throw new DriveUploadError(
+    "Google Drive の認証が設定されていません。設定画面からGoogle Driveに接続してください。",
+    "env_not_configured",
+  );
 }
 
 export async function uploadToDrive(
@@ -17,9 +54,16 @@ export async function uploadToDrive(
   fileName: string,
   mimeType: string,
 ): Promise<string> {
-  const auth = getAuth();
+  const { auth, isOAuth } = await getAuth();
   const drive = google.drive({ version: "v3", auth });
   const folderId = process.env.GOOGLE_DRIVE_FOLDER_ID;
+
+  console.log("[Google Drive] アップロード開始:", {
+    fileName,
+    mimeType,
+    authMode: isOAuth ? "OAuth" : "ServiceAccount",
+    folderId: folderId || "(未設定)",
+  });
 
   const response = await drive.files.create({
     requestBody: {
@@ -31,18 +75,30 @@ export async function uploadToDrive(
       body: Readable.from(fileBuffer),
     },
     fields: "id, webViewLink",
+    supportsAllDrives: true,
   });
 
-  // 共有リンクを有効化
-  if (response.data.id) {
+  console.log("[Google Drive] ファイル作成成功:", {
+    fileId: response.data.id,
+    authMode: isOAuth ? "OAuth" : "ServiceAccount",
+  });
+
+  // OAuth モードでは permissions.create をスキップ
+  // ユーザー自身がオーナーのため、公開共有は不要
+  if (!isOAuth && response.data.id) {
     await drive.permissions.create({
       fileId: response.data.id,
       requestBody: {
         role: "reader",
         type: "anyone",
       },
+      supportsAllDrives: true,
     });
+    console.log("[Google Drive] 共有設定成功");
   }
 
-  return response.data.webViewLink || `https://drive.google.com/file/d/${response.data.id}/view`;
+  return (
+    response.data.webViewLink ||
+    `https://drive.google.com/file/d/${response.data.id}/view`
+  );
 }

--- a/src/lib/google-drive.ts
+++ b/src/lib/google-drive.ts
@@ -34,12 +34,19 @@ async function getAuth(): Promise<AuthResult> {
   // 2. サービスアカウントにフォールバック
   const keyJson = process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
   if (keyJson) {
-    const key = JSON.parse(keyJson);
-    const googleAuth = new google.auth.GoogleAuth({
-      credentials: key,
-      scopes: ["https://www.googleapis.com/auth/drive.file"],
-    });
-    return { auth: googleAuth, isOAuth: false };
+    try {
+      const key = JSON.parse(keyJson);
+      const googleAuth = new google.auth.GoogleAuth({
+        credentials: key,
+        scopes: ["https://www.googleapis.com/auth/drive.file"],
+      });
+      return { auth: googleAuth, isOAuth: false };
+    } catch {
+      throw new DriveUploadError(
+        "GOOGLE_SERVICE_ACCOUNT_KEY の形式が不正です",
+        "invalid_config",
+      );
+    }
   }
 
   // 3. どちらもない

--- a/src/lib/google-oauth.ts
+++ b/src/lib/google-oauth.ts
@@ -1,0 +1,158 @@
+import { google } from "googleapis";
+import { supabase } from "@/lib/supabase";
+
+const SCOPES = [
+  "https://www.googleapis.com/auth/drive.file",
+  "https://www.googleapis.com/auth/userinfo.email",
+];
+
+/**
+ * OAuth2 クライアントを生成
+ */
+export function getOAuth2Client() {
+  const clientId = process.env.GOOGLE_OAUTH_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      "GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET must be set",
+    );
+  }
+
+  const baseUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+  const redirectUri = `${baseUrl}/api/auth/google/callback`;
+
+  return new google.auth.OAuth2(clientId, clientSecret, redirectUri);
+}
+
+/**
+ * Google 同意画面の URL を生成
+ */
+export function getAuthUrl(returnTo: string): string {
+  const client = getOAuth2Client();
+  return client.generateAuthUrl({
+    access_type: "offline",
+    prompt: "consent",
+    scope: SCOPES,
+    state: returnTo,
+  });
+}
+
+/**
+ * 認証コードをトークンに交換し、メールアドレスも取得
+ */
+export async function exchangeCode(
+  code: string,
+): Promise<{ refreshToken: string; email: string }> {
+  const client = getOAuth2Client();
+  const { tokens } = await client.getToken(code);
+
+  if (!tokens.refresh_token) {
+    throw new Error("No refresh token received from Google");
+  }
+
+  // アクセストークンでメールアドレスを取得
+  client.setCredentials(tokens);
+  const oauth2 = google.oauth2({ version: "v2", auth: client });
+  const { data } = await oauth2.userinfo.get();
+
+  if (!data.email) {
+    throw new Error("Failed to retrieve email from Google");
+  }
+
+  return {
+    refreshToken: tokens.refresh_token,
+    email: data.email,
+  };
+}
+
+/**
+ * リフレッシュトークンとメールを review_settings に保存
+ */
+export async function saveTokens(
+  refreshToken: string,
+  email: string,
+): Promise<void> {
+  const now = new Date().toISOString();
+
+  const { error: tokenError } = await supabase
+    .from("review_settings")
+    .upsert(
+      { key: "google_drive_refresh_token", value: refreshToken, updated_at: now },
+      { onConflict: "key" },
+    );
+
+  if (tokenError) {
+    throw new Error(`Failed to save refresh token: ${tokenError.message}`);
+  }
+
+  const { error: emailError } = await supabase
+    .from("review_settings")
+    .upsert(
+      { key: "google_drive_email", value: email, updated_at: now },
+      { onConflict: "key" },
+    );
+
+  if (emailError) {
+    throw new Error(`Failed to save email: ${emailError.message}`);
+  }
+}
+
+/**
+ * DBからリフレッシュトークンを取得し、認証済み OAuth2 クライアントを返す
+ * 未設定の場合は null を返す
+ */
+export async function getStoredAuth() {
+  const { data, error } = await supabase
+    .from("review_settings")
+    .select("key, value")
+    .eq("key", "google_drive_refresh_token")
+    .single();
+
+  if (error || !data?.value) {
+    return null;
+  }
+
+  const client = getOAuth2Client();
+  client.setCredentials({ refresh_token: data.value });
+  return client;
+}
+
+/**
+ * トークンを取り消し、DBから削除
+ */
+export async function revokeAndClear(): Promise<void> {
+  // DBからトークンを取得して Google に revoke リクエスト
+  const { data } = await supabase
+    .from("review_settings")
+    .select("key, value")
+    .eq("key", "google_drive_refresh_token")
+    .single();
+
+  if (data?.value) {
+    try {
+      const client = getOAuth2Client();
+      await client.revokeToken(data.value);
+    } catch {
+      // revoke 失敗してもDB削除は続行
+      console.warn("[Google OAuth] Token revocation failed, continuing cleanup");
+    }
+  }
+
+  const now = new Date().toISOString();
+
+  await supabase
+    .from("review_settings")
+    .upsert(
+      { key: "google_drive_refresh_token", value: "", updated_at: now },
+      { onConflict: "key" },
+    );
+
+  await supabase
+    .from("review_settings")
+    .upsert(
+      { key: "google_drive_email", value: "", updated_at: now },
+      { onConflict: "key" },
+    );
+}

--- a/src/lib/google-oauth.ts
+++ b/src/lib/google-oauth.ts
@@ -1,4 +1,5 @@
 import { google } from "googleapis";
+import type { OAuth2Client } from "google-auth-library";
 import { supabase } from "@/lib/supabase";
 
 const SCOPES = [
@@ -103,7 +104,7 @@ export async function saveTokens(
  * DBからリフレッシュトークンを取得し、認証済み OAuth2 クライアントを返す
  * 未設定の場合は null を返す
  */
-export async function getStoredAuth() {
+export async function getStoredAuth(): Promise<OAuth2Client | null> {
   const { data, error } = await supabase
     .from("review_settings")
     .select("key, value")
@@ -142,17 +143,25 @@ export async function revokeAndClear(): Promise<void> {
 
   const now = new Date().toISOString();
 
-  await supabase
+  const { error: tokenError } = await supabase
     .from("review_settings")
     .upsert(
       { key: "google_drive_refresh_token", value: "", updated_at: now },
       { onConflict: "key" },
     );
 
-  await supabase
+  if (tokenError) {
+    console.error("[Google OAuth] Failed to clear refresh token:", tokenError.message);
+  }
+
+  const { error: emailError } = await supabase
     .from("review_settings")
     .upsert(
       { key: "google_drive_email", value: "", updated_at: now },
       { onConflict: "key" },
     );
+
+  if (emailError) {
+    console.error("[Google OAuth] Failed to clear email:", emailError.message);
+  }
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -90,7 +90,10 @@ INSERT INTO review_settings (key, value) VALUES
   ('auto_skip_threshold', '30'),
   ('scoring_enabled', 'true'),
   ('auto_collect_enabled', 'true'),
-  ('notion_database_id', '');
+  ('notion_database_id', ''),
+  ('google_drive_refresh_token', ''),  -- Google OAuth refresh token
+  ('google_drive_email', '')           -- Connected Google account email
+ON CONFLICT (key) DO NOTHING;
 
 -- インデックス
 CREATE INDEX idx_papers_collected_at ON papers(collected_at DESC);


### PR DESCRIPTION
## Summary

- Google Drive OAuth 2.0 認証の基盤ライブラリ `src/lib/google-oauth.ts` を新規作成
- サービスアカウントのストレージクォータ制限を回避するため、ユーザー自身のGoogleアカウントでアップロードする方式の基盤
- 既存の `review_settings` テーブルを利用したトークン永続化（Notion設定と同じパターン）

### 実装した関数
| 関数 | 役割 |
|------|------|
| `getOAuth2Client()` | OAuth2クライアント生成 |
| `getAuthUrl(returnTo)` | Google同意画面URL生成 |
| `exchangeCode(code)` | 認証コード→トークン交換+メール取得 |
| `saveTokens(refreshToken, email)` | DBにトークン保存 |
| `getStoredAuth()` | DBからトークン取得→認証済みクライアント返却 |
| `revokeAndClear()` | トークン取り消し+DB削除 |

## Test plan

- [ ] `getOAuth2Client()` が環境変数未設定時にエラーをスローする
- [ ] `getAuthUrl()` が正しいスコープ・パラメータでURLを生成する
- [ ] `saveTokens()` で `review_settings` にトークン・メールが保存される
- [ ] `getStoredAuth()` がトークン未設定時に `null` を返す
- [ ] `getStoredAuth()` がトークン設定時に認証済みOAuth2クライアントを返す
- [ ] `revokeAndClear()` でトークンが取り消され、DBから削除される
- [ ] TypeScript型エラーがない
- [ ] ESLintエラーがない

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)