### PR TITLE
feat: スキャンPDFのGeminiマルチモーダルOCR対応

### DIFF
--- a/src/app/api/pdf/parse/route.ts
+++ b/src/app/api/pdf/parse/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { extractMetadata } from "@/lib/ai";
+import { extractMetadata, extractMetadataFromPdf } from "@/lib/ai";
 
 export async function POST(request: NextRequest) {
   try {
@@ -19,8 +19,8 @@ export async function POST(request: NextRequest) {
     const pdfData = await pdfParse(buffer);
 
     const text = (pdfData.text || "") as string;
+    const isTextSufficient = text.length > 50;
 
-    // AIでメタデータを構造化抽出
     let metadata = {
       title: "",
       authors: [] as string[],
@@ -29,20 +29,40 @@ export async function POST(request: NextRequest) {
       doi: null as string | null,
       abstract: null as string | null,
     };
+    let extractedText = text;
+    let ocrUsed = false;
 
-    if (text.length > 50) {
+    if (isTextSufficient) {
+      // テキストベースPDF: 従来のテキスト抽出 → AIメタデータ抽出
       try {
         metadata = await extractMetadata(text);
       } catch (e) {
         console.error("[PDF Parse] AI metadata extraction failed:", e);
-        // AI抽出失敗時はPDFメタデータにフォールバック
+      }
+    } else {
+      // スキャンPDF: Geminiマルチモーダルでテキスト+メタデータを一括抽出
+      console.log("[PDF Parse] テキスト不足 (%d文字)、Geminiマルチモーダルにフォールバック", text.length);
+      try {
+        const result = await extractMetadataFromPdf(buffer);
+        metadata = {
+          title: result.title,
+          authors: result.authors,
+          journal: result.journal,
+          published_date: result.published_date,
+          doi: result.doi,
+          abstract: result.abstract,
+        };
+        extractedText = result.text || text;
+        ocrUsed = true;
+      } catch (e) {
+        console.error("[PDF Parse] Geminiマルチモーダル抽出失敗:", e);
       }
     }
 
     // AIで取得できなかった場合はPDFメタデータにフォールバック
     const info = pdfData.info || {};
     if (!metadata.title) {
-      const lines = text.split("\n").filter((l: string) => l.trim().length > 0);
+      const lines = extractedText.split("\n").filter((l: string) => l.trim().length > 0);
       metadata.title = info.Title || lines[0]?.trim() || "";
     }
     if (metadata.authors.length === 0 && info.Author) {
@@ -56,8 +76,9 @@ export async function POST(request: NextRequest) {
       published_date: metadata.published_date,
       doi: metadata.doi,
       abstract: metadata.abstract,
-      text: text.slice(0, 12000),
+      text: extractedText.slice(0, 12000),
       pages: pdfData.numpages,
+      ocr_used: ocrUsed,
     });
   } catch (error) {
     console.error("[PDF Parse Error]", error);

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -249,6 +249,80 @@ export async function extractMetadata(text: string): Promise<{
   }
 }
 
+// PDFバイナリ（スキャンPDF含む）からGeminiマルチモーダルでメタデータ・テキストを抽出
+export async function extractMetadataFromPdf(pdfBuffer: Buffer): Promise<{
+  title: string;
+  authors: string[];
+  journal: string | null;
+  published_date: string | null;
+  doi: string | null;
+  abstract: string | null;
+  text: string;
+}> {
+  const base64Data = pdfBuffer.toString("base64");
+
+  const response = await getClient().models.generateContent({
+    model: MODEL,
+    contents: [
+      {
+        role: "user",
+        parts: [
+          {
+            inlineData: {
+              mimeType: "application/pdf",
+              data: base64Data,
+            },
+          },
+          {
+            text: `この論文PDFを読み取り、以下の情報をJSON形式で出力してください。
+
+出力形式（JSONのみ出力、他のテキストは不要）:
+{
+  "title": "論文タイトル（原文のまま）",
+  "authors": ["著者1", "著者2", ...],
+  "journal": "ジャーナル名または会議名（見つからなければnull）",
+  "published_date": "YYYY-MM-DD形式（年のみの場合はYYYY-01-01、見つからなければnull）",
+  "doi": "DOI（見つからなければnull）",
+  "abstract": "アブストラクト全文（見つからなければnull）",
+  "text": "論文の本文テキスト全体（最大8000文字程度）"
+}
+
+注意事項：
+- PDFの画像・テキストすべてを読み取ってください
+- テキストに記載されている情報のみを抽出してください
+- 推測や補完はしないでください
+- 著者名は論文に記載された表記のまま抽出してください
+- DOIは "10." で始まる文字列を探してください
+- textフィールドには論文の本文をできるだけ多く含めてください`,
+          },
+        ],
+      },
+    ],
+    config: {
+      responseMimeType: "application/json",
+      temperature: 0.1,
+      maxOutputTokens: 4096,
+      thinkingConfig: { thinkingBudget: 0 },
+    },
+  });
+
+  const content = response.text?.trim() || "{}";
+  try {
+    const parsed = JSON.parse(content);
+    return {
+      title: parsed.title || "",
+      authors: Array.isArray(parsed.authors) ? parsed.authors : [],
+      journal: parsed.journal || null,
+      published_date: parsed.published_date || null,
+      doi: parsed.doi || null,
+      abstract: parsed.abstract || null,
+      text: typeof parsed.text === "string" ? parsed.text : "",
+    };
+  } catch {
+    return { title: "", authors: [], journal: null, published_date: null, doi: null, abstract: null, text: "" };
+  }
+}
+
 export async function processAllAI(paper: {
   title_original: string;
   authors?: string[];


### PR DESCRIPTION
## Summary
- スキャンPDF（画像ベースPDF）からのテキスト抽出・メタデータ抽出をGemini 2.5 Flashマルチモーダルで対応
- `pdf-parse`でテキストが50文字未満の場合、PDFバイナリをGemini APIにinlineDataとして送信するフォールバック
- レスポンスに`ocr_used`フラグを追加し、フォールバック使用を明示

## Test plan
- [ ] テキストベースPDFのアップロード → 従来通り動作すること
- [ ] スキャンPDFのアップロード → Geminiフォールバックでメタデータ・テキストが取得されること
- [ ] レスポンスの`ocr_used`フラグが適切に設定されること

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)