### PR TITLE
fix: Google Drive OAuthスコープをdriveに変更

### DIFF
--- a/src/lib/google-oauth.ts
+++ b/src/lib/google-oauth.ts
@@ -3,7 +3,7 @@ import type { OAuth2Client } from "google-auth-library";
 import { supabase } from "@/lib/supabase";
 
 const SCOPES = [
-  "https://www.googleapis.com/auth/drive.file",
+  "https://www.googleapis.com/auth/drive",
   "https://www.googleapis.com/auth/userinfo.email",
 ];
 


### PR DESCRIPTION
## Summary
- Google Drive OAuth スコープを `drive.file` から `drive` に変更
- `drive.file` スコープではアプリ外で作成されたフォルダへの `parents` 指定アップロードが拒否される

## 注意事項
デプロイ後、設定画面から **Google Drive を切断→再接続** が必要（新しいスコープでトークンを再取得するため）

## Test plan
- [x] lint パス確認
- [x] ビルド成功確認
- [ ] 切断→再接続後に PDF アップロードが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
