### PR TITLE
fix: 論文登録時の既存論文上書きが反映されない問題を修正

### DIFF
--- a/src/app/api/papers/[id]/route.ts
+++ b/src/app/api/papers/[id]/route.ts
@@ -16,6 +16,13 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   return NextResponse.json(data);
 }
 
+const UPDATABLE_FIELDS = new Set([
+  "title_original", "title_ja", "authors", "published_date", "journal",
+  "doi", "url", "summary_ja", "explanation_ja", "source",
+  "google_drive_url", "is_favorite", "memo", "review_status",
+  "relevance_score", "abstract", "notion_page_id", "notion_page_url",
+]);
+
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -23,9 +30,20 @@ export async function PATCH(
   const { id } = await params;
   const body = await request.json();
 
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(body)) {
+    if (UPDATABLE_FIELDS.has(key)) {
+      sanitized[key] = value;
+    }
+  }
+
+  if (Object.keys(sanitized).length === 0) {
+    return NextResponse.json({ error: "更新するフィールドがありません" }, { status: 400 });
+  }
+
   const { data, error } = await supabase
     .from("papers")
-    .update(body)
+    .update(sanitized)
     .eq("id", id)
     .select()
     .single();

--- a/src/app/papers/new/page.tsx
+++ b/src/app/papers/new/page.tsx
@@ -315,18 +315,19 @@ export default function NewPaperPage() {
         url: form.url.trim() || null,
         memo: form.memo.trim() || null,
         abstract: pdfAbstract || null,
-        google_drive_url: googleDriveUrl,
       };
+
+      // Google Drive URL: 新規アップロード成功時のみ設定、上書き時は既存を維持
+      if (googleDriveUrl) {
+        body.google_drive_url = googleDriveUrl;
+      } else if (!overwriteId) {
+        body.google_drive_url = null;
+      }
 
       // AI結果があれば含める
       if (aiResult) {
         body.summary_ja = aiEdited.summary_ja.trim() || null;
         body.explanation_ja = aiEdited.explanation_ja.trim() || null;
-      }
-
-      // AI未実行の場合、PDFテキストを渡してバックグラウンド生成に使う
-      if (!aiResult && pdfText) {
-        body.text = pdfText;
       }
 
       let res: Response;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -13,6 +13,7 @@ CREATE TABLE papers (
   journal TEXT,
   doi TEXT UNIQUE,
   url TEXT,
+  abstract TEXT,
   summary_ja TEXT,
   explanation_ja TEXT,
   source TEXT NOT NULL DEFAULT 'manual',


### PR DESCRIPTION
## Summary
- `handleSubmit` から `text` フィールド（papersテーブルに存在しないカラム）の送信を除去し、PATCH時のSupabaseエラーを解消
- 上書きモードで `google_drive_url` を条件付き送信に変更し、アップロード未実施/失敗時に既存URLが消えないよう修正
- PATCH API に `UPDATABLE_FIELDS` ホワイトリストを導入し、未知フィールドをSupabaseに渡さないよう防御

## 受け入れ基準
- [x] PDFアップロード後に既存論文の上書きが正常に動作する
- [x] 上書き時にGoogle Drive未接続でも、既存のDrive URLが消えない
- [x] PATCH APIが未知のフィールドを無視し、既知カラムのみ更新する
- [x] `npm run build` が通る

## Test plan
- [ ] PDFアップロード → 既存論文マッチ → 「既存を上書き」→ 上書きが正常に反映される
- [ ] 上書き時、Google Drive未接続でもエラーにならず、既存のDrive URLが保持される
- [ ] 不正なフィールドを含むPATCHリクエストがサニタイズされ、既知カラムのみ更新される
- [ ] lint パス確認
- [ ] ビルド成功確認

## 確認ポイント
- PATCH API のホワイトリストが全必要カラムを網羅しているか
- 新規登録パスの動作に影響がないか（`google_drive_url: null` は新規時のみ送信）

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)
