### PR TITLE
fix: Google Drive Resumable UploadのCORSエラーを修正

### DIFF
--- a/src/app/api/drive/upload/init/route.ts
+++ b/src/app/api/drive/upload/init/route.ts
@@ -64,16 +64,22 @@ export async function POST(request: NextRequest) {
     }
 
     // Resumable upload セッションを開始
+    const initHeaders: Record<string, string> = {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json; charset=UTF-8",
+      "X-Upload-Content-Type": mimeType,
+      "X-Upload-Content-Length": String(fileSize),
+    };
+    const origin = request.headers.get("Origin");
+    if (origin) {
+      initHeaders["Origin"] = origin;
+    }
+
     const initRes = await fetch(
       "https://www.googleapis.com/upload/drive/v3/files?uploadType=resumable&supportsAllDrives=true",
       {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          "Content-Type": "application/json; charset=UTF-8",
-          "X-Upload-Content-Type": mimeType,
-          "X-Upload-Content-Length": String(fileSize),
-        },
+        headers: initHeaders,
         body: JSON.stringify(metadata),
       },
     );


### PR DESCRIPTION
## Summary
- Google Drive Resumable Uploadのセッション開始時にクライアントの`Origin`ヘッダーをGoogle APIに転送するよう修正
- これにより、返却される`uploadUri`にCORS許可が含まれ、ブラウザからの直接PUTアップロードが成功する

## 受け入れ基準
- [ ] 論文詳細画面（`/papers/[id]`）から「PDFを登録」でGoogle Driveにアップロードできる
- [ ] 論文登録画面（`/papers/new`）から登録時にPDFがGoogle Driveにアップロードされる
- [ ] Vercel デプロイ後の本番環境で動作確認
- [x] `npm run build` が通る

## Test plan
- [x] lint パス確認（既存エラーのみ）
- [x] ビルド成功確認
- [ ] 論文詳細画面からPDFアップロード → Google Driveに保存される
- [ ] 論文登録画面からPDFアップロード → Google Driveに保存される
- [ ] 大きいPDF（> 4.5MB）でも正常にアップロードできる

## 確認ポイント
- `Origin`ヘッダーが存在する場合のみ転送（サーバーサイドからの呼び出しには影響なし）
- 既存のバリデーション・エラーハンドリングに変更なし

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)
